### PR TITLE
Adds getName to Collection Entity

### DIFF
--- a/lib/Shelf/Entity/AbstractName.php
+++ b/lib/Shelf/Entity/AbstractName.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Shelf\Entity;
+
+use Shelf\Entity\AbstractDataEntity;
+
+/**
+ * Class used to represent a name of an entity
+ */
+abstract class AbstractName extends AbstractDataEntity
+{
+    /**
+     * Returns the sort index with an option to make it zero based
+     *
+     * @param boolean $zeroBased OPTIONAL
+     *
+     * @return int
+     */
+    public function getSortIndex($zeroBased = false)
+    {
+        $sortIndex = parent::getSortIndex();
+        if ($zeroBased) {
+            --$sortIndex;
+        }
+        return $sortIndex;
+    }
+
+    /**
+     * Returns the value starting with the sort index
+     *
+     * @param $appendPreSort OPTIONAL Controls whether the characters pre-sort
+     *                                index are appended to returned result
+     *
+     * @return string
+     */
+    public function getSortValue($appendPreSort = true)
+    {
+        $value = $this->getValue();
+        $sortIndex = $this->getSortIndex(true);
+
+        $sortValue = substr($value, $sortIndex);
+        if ($appendPreSort && $sortIndex > 0) {
+            $sortValue .= ', ' . substr($value, 0, $sortIndex - 1);
+        }
+        return $sortValue;
+    }
+}

--- a/lib/Shelf/Entity/Boardgame/Name.php
+++ b/lib/Shelf/Entity/Boardgame/Name.php
@@ -2,13 +2,13 @@
 
 namespace Shelf\Entity\Boardgame;
 
-use Shelf\Entity\AbstractDataEntity;
+use Shelf\Entity\AbstractName;
 
 /**
  * Class used to represent the name of a board game and the various properties
  * associated with that name
  */
-class Name extends AbstractDataEntity
+class Name extends AbstractName
 {
     /**
      * Returns true if the name is considered to be the primary name
@@ -18,41 +18,5 @@ class Name extends AbstractDataEntity
     public function isPrimary()
     {
         return $this->getType() == 'primary';
-    }
-
-    /**
-     * Returns the sort index with an option to make it zero based
-     *
-     * @param boolean $zeroBased OPTIONAL
-     *
-     * @return int
-     */
-    public function getSortIndex($zeroBased = false)
-    {
-        $sortIndex = parent::getSortIndex();
-        if ($zeroBased) {
-            --$sortIndex;
-        }
-        return $sortIndex;
-    }
-
-    /**
-     * Returns the value starting with the sort index
-     *
-     * @param $appendPreSort OPTIONAL Controls whether the characters pre-sort
-     *                                index are appended to returned result
-     *
-     * @return string
-     */
-    public function getSortValue($appendPreSort = true)
-    {
-        $value = $this->getValue();
-        $sortIndex = $this->getSortIndex(true);
-
-        $sortValue = substr($value, $sortIndex);
-        if ($appendPreSort) {
-            $sortValue .= ', ' . substr($value, 0, $sortIndex - 1);
-        }
-        return $sortValue;
     }
 }

--- a/lib/Shelf/Entity/Collection.php
+++ b/lib/Shelf/Entity/Collection.php
@@ -2,6 +2,7 @@
 
 namespace Shelf\Entity;
 
+use Shelf\Entity\Collection\Name;
 use Shelf\Factory\CollectionFactory;
 
 /**
@@ -10,6 +11,27 @@ use Shelf\Factory\CollectionFactory;
  */
 class Collection extends AbstractDataEntity
 {
+    /**
+     * Entity to represent the name of a collection
+     *
+     * @var Name
+     */
+    protected $nameEntity = null;
+
+    /**
+     * Returns a name entity
+     *
+     * @return Name
+     */
+    public function getName()
+    {
+        if ($this->nameEntity === null) {
+            $this->nameEntity = Name::factory(parent::getName());
+        }
+
+        return $this->nameEntity;
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/lib/Shelf/Entity/Collection/Name.php
+++ b/lib/Shelf/Entity/Collection/Name.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Shelf\Entity\Collection;
+
+use Shelf\Entity\AbstractName;
+
+/**
+ * Class used to represent the name of a board game and the various properties
+ * associated with that name
+ */
+class Name extends AbstractName
+{
+}

--- a/tests/Shelf/Test/Entity/AbstractNameTest.php
+++ b/tests/Shelf/Test/Entity/AbstractNameTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Shelf\Test\Entity;
+
+class AbstractNameTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetSortIndex()
+    {
+        $name = $this->getMockForAbstractClass(
+            'Shelf\Entity\AbstractName',
+            array(
+                array(
+                    'value' => 'Roads and Boats',
+                    'sort_index' => 1,
+                )
+            )
+        );
+
+        $this->assertEquals(1, $name->getSortIndex());
+        $this->assertEquals(1, $name->getSortIndex(false));
+        $this->assertEquals(0, $name->getSortIndex(true));
+    }
+
+    public function testGetSortValue()
+    {
+        $name = $this->getMockForAbstractClass(
+            'Shelf\Entity\AbstractName',
+            array(
+                array(
+                    'value' => 'Roads and Boats',
+                    'sort_index' => 1,
+                )
+            )
+        );
+
+        $this->assertEquals('Roads and Boats', $name->getSortValue());
+        $this->assertEquals('Roads and Boats', $name->getSortValue(true));
+    }
+
+    public function testGetSortValueNoAppend()
+    {
+        $name = $this->getMockForAbstractClass(
+            'Shelf\Entity\AbstractName',
+            array(
+                array(
+                    'value' => 'Roads and Boats',
+                    'sort_index' => 1,
+                )
+            )
+        );
+
+        $this->assertEquals('Roads and Boats', $name->getSortValue(false));
+    }
+
+    public function testGetSortValueWithSortIndex()
+    {
+        $name = $this->getMockForAbstractClass(
+            'Shelf\Entity\AbstractName',
+            array(
+                array(
+                    'value' => 'Roads and Boats',
+                    'sort_index' => 11,
+                )
+            )
+        );
+
+        $this->assertEquals('Boats, Roads and', $name->getSortValue());
+        $this->assertEquals('Boats, Roads and', $name->getSortValue(true));
+    }
+
+    public function testGetSortValueWithSortIndexNoAppend()
+    {
+        $name = $this->getMockForAbstractClass(
+            'Shelf\Entity\AbstractName',
+            array(
+                array(
+                    'value' => 'Roads and Boats',
+                    'sort_index' => 11,
+                )
+            )
+        );
+
+        $this->assertEquals('Boats', $name->getSortValue(false));
+    }
+}

--- a/tests/Shelf/Test/Entity/Boardgame/CollectionTest.php
+++ b/tests/Shelf/Test/Entity/Boardgame/CollectionTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Shelf\Test\Entity;
+
+use Shelf\Factory\CollectionFactory;
+
+class CollectionTest extends \PHPUnit_Framework_TestCase
+{
+    public static $collection;
+
+    public function testGetName()
+    {
+        $collection = CollectionFactory::fromArray(array(
+            'name' => array(
+                'value' => 'Roads and Boats',
+                'sort_index' => 1,
+            )
+        ));
+        $name = $collection->getName();
+
+        $this->assertInstanceOf(
+            'Shelf\\Entity\\Collection\\Name',
+            $name
+        );
+
+        $this->assertEquals('Roads and Boats', $name->getValue());
+    }
+}

--- a/tests/Shelf/Test/Entity/Boardgame/NameTest.php
+++ b/tests/Shelf/Test/Entity/Boardgame/NameTest.php
@@ -33,26 +33,4 @@ class NameTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(self::$primaryName->isPrimary());
         $this->assertFalse(self::$alternateName->isPrimary());
     }
-
-    public function testGetSortIndex()
-    {
-        $this->assertEquals(5, self::$primaryName->getSortIndex());
-        $this->assertEquals(5, self::$primaryName->getSortIndex(false));
-        $this->assertEquals(4, self::$primaryName->getSortIndex(true));
-    }
-
-    public function testGetSortValue()
-    {
-        $this->assertEquals('Primary Name, The', self::$primaryName->getSortValue());
-        $this->assertEquals('Primary Name, The', self::$primaryName->getSortValue(true));
-
-        $this->assertEquals('Alternate Name, An', self::$alternateName->getSortValue());
-        $this->assertEquals('Alternate Name, An', self::$alternateName->getSortValue(true));
-    }
-
-    public function testGetSortValueNoAppend()
-    {
-        $this->assertEquals('Primary Name', self::$primaryName->getSortValue(false));
-        $this->assertEquals('Alternate Name', self::$alternateName->getSortValue(false));
-    }
 }


### PR DESCRIPTION
Adds a getName method to the Collection entity. This resulted in the
Boardgame Name entity having some methods move out to an AbstractName
entity which the Boardgame and Collection name entities then extend
from.

Adds tests for new classes and methods. Fixes an issue with getting
the sort name when the sort_index is 1.
