### PR TITLE
Tell Travis to Only Build Master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,7 @@ php:
   - "5.3"
 
 before_script: composer install
+
+branches:
+  only:
+   - master


### PR DESCRIPTION
I often push branches up that I don't care if they pass or fail. I am
only interested in master passing and pull requests to master. Updates
Travis config to whitelist master branch only.
